### PR TITLE
Prevents NPE after second checkDevice() call

### DIFF
--- a/src/android/secureDevice.java
+++ b/src/android/secureDevice.java
@@ -71,9 +71,12 @@ public class secureDevice extends CordovaPlugin {
         if (_isDeviceRooted || !_isPasscodeSet) {
             // Remove View
             View v = this.view.getView();
-            ViewGroup viewParent = (ViewGroup) v.getParent();
-            viewParent.removeView(v);
-
+            if (v != null) {
+                ViewGroup viewParent = (ViewGroup) v.getParent();
+                if (viewParent != null) {
+                    viewParent.removeView(v);
+                }
+            }
             // Show message and quit
             Application app = cordova.getActivity().getApplication();
             String package_name = app.getPackageName();


### PR DESCRIPTION
Naïve fix for #1 , preventing NPE to be thrown.
Doesn't prevent the second call of checkDevice to happen nor a second dialog to be opened but, given that the handler of the dialog always exits the application, it doesn't seem to be a problem at all.